### PR TITLE
Allow finding installed xtb version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,18 +13,32 @@ enable_language(Fortran)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/dev/cmake)
 
 # Find xtb
-find_package(xtb QUIET)
-if(NOT TARGET lib-xtb-static)
-  include(DownloadProject)
-  download_project(
-    PROJ xtb
-    GIT_REPOSITORY https://github.com/grimme-lab/xtb.git
-    GIT_TAG v6.4.1
-    QUIET
-    UPDATE_DISCONNECTED 1
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(XTB REQUIRED xtb)
+if(XTB_FOUND)
+  add_library(xtb::xtb INTERFACE IMPORTED)
+  target_link_libraries(
+    xtb::xtb
+    INTERFACE
+    ${XTB_LINK_LIBRARIES}
   )
-  add_subdirectory(${xtb_SOURCE_DIR} ${xtb_BINARY_DIR})
+  target_include_directories(
+    xtb::xtb
+    INTERFACE
+    ${XTB_INCLUDE_DIRS}
+  )
+else()
+  include(FetchContent)
+  FetchContent_Declare(
+    xtb
+    GIT_REPOSITORY "https://github.com/grimme-lab/xtb"
+    GIT_TAG "v6.4.1"
+  )
+  FetchContent_MakeAvailable(xtb)
+
+  add_library(xtb::xtb INTERFACE IMPORTED)
   if(TARGET lib-xtb-static)
+    target_link_libraries(xtb::xtb INTERFACE lib-xtb-static)
     message(STATUS "xtb was not found in your PATH, so it was downloaded.")
   else()
     string(CONCAT error_msg

--- a/src/Xtb/CMakeLists.txt
+++ b/src/Xtb/CMakeLists.txt
@@ -31,7 +31,7 @@ set_target_properties(Xtb PROPERTIES
 target_link_libraries(Xtb
   PRIVATE
     Scine::UtilsOS
-    lib-xtb-static
+    xtb::xtb
     gfortran
   PUBLIC
     Scine::CoreHeaders


### PR DESCRIPTION
This should ensure `xtb` installed by meson can be discovered correctly.

Fixes #1 